### PR TITLE
[fix] 두번째 페이지: 누적퀘스트 추가 기능 버그 수정

### DIFF
--- a/lib/first_page/first_page.dart
+++ b/lib/first_page/first_page.dart
@@ -54,7 +54,7 @@ class _FirstPageState extends State<FirstPage> {
 
   void _insertAccumulatedQuest(String key) {
     _accumulatedQuestListBox.put(key,AccumulatedQuest(
-      quest: Quest(name: key, isDone: false),
+      quest: DailyQuest(name: key, isDone: false),
     )).then((_) {
       _updateBox();
    });

--- a/lib/second_page/second_page.dart
+++ b/lib/second_page/second_page.dart
@@ -44,8 +44,8 @@ class _SecondPageState extends State<SecondPage> {
           DailyRecord(
             date: DateTime.now(),
             diary: '',
-            accumulatedQuestList: [],
-            normalQuestList: [],
+            dailyQuestList_accumulated: [],
+            dailyQuestList_normal: [],
             facialExpressionIndex: -1,
             isSaved: false,
           );          
@@ -61,8 +61,8 @@ class _SecondPageState extends State<SecondPage> {
           DailyRecord(
             date: DateTime.now(),
             diary: '',
-            accumulatedQuestList: [],
-            normalQuestList: [],
+            dailyQuestList_accumulated: [],
+            dailyQuestList_normal: [],
             facialExpressionIndex: -1,
             isSaved: false,
           );
@@ -87,10 +87,10 @@ class _SecondPageState extends State<SecondPage> {
   Future _updateAccumulatedQuest(int index) async {
     for (var accumulatedQuest in _accumulatedQuestList) {
       if (accumulatedQuest.quest.name ==
-          _dailyRecord.accumulatedQuestList[index].name) {
+          _dailyRecord.dailyQuestList_accumulated[index].name) {
 
         DateTime date = normalize(DateTime.now());
-        if (_dailyRecord.accumulatedQuestList[index].isDone) {
+        if (_dailyRecord.dailyQuestList_accumulated[index].isDone) {
           accumulatedQuest.dates.remove(date);
         } else {
           if (!accumulatedQuest.dates.contains(date)) {
@@ -102,8 +102,8 @@ class _SecondPageState extends State<SecondPage> {
     }
 
     setState(() {
-      _dailyRecord.accumulatedQuestList[index].isDone =
-          !_dailyRecord.accumulatedQuestList[index].isDone;
+      _dailyRecord.dailyQuestList_accumulated[index].isDone =
+          !_dailyRecord.dailyQuestList_accumulated[index].isDone;
     });
 
     await _saveDailyRecord();
@@ -111,7 +111,7 @@ class _SecondPageState extends State<SecondPage> {
 
   Future _deleteAccumulatedQuest(int index) async {
     setState(() {
-      _dailyRecord.accumulatedQuestList.removeAt(index);
+      _dailyRecord.dailyQuestList_accumulated.removeAt(index);
     });
 
     await _saveDailyRecord();
@@ -119,8 +119,8 @@ class _SecondPageState extends State<SecondPage> {
 
   Future _updateNormalQuest(int index) async {
     setState(() {
-      _dailyRecord.normalQuestList[index].isDone =
-          !_dailyRecord.normalQuestList[index].isDone;
+      _dailyRecord.dailyQuestList_normal[index].isDone =
+          !_dailyRecord.dailyQuestList_normal[index].isDone;
     });
 
     await _saveDailyRecord();
@@ -128,7 +128,7 @@ class _SecondPageState extends State<SecondPage> {
 
   Future _deleteNormalQuest(int index) async {
     setState(() {
-      _dailyRecord.normalQuestList.removeAt(index);
+      _dailyRecord.dailyQuestList_normal.removeAt(index);
     });
 
     await _saveDailyRecord();
@@ -203,22 +203,25 @@ class _SecondPageState extends State<SecondPage> {
   }
 
   void _showAccumulatedQuestModal(BuildContext context) {
-    List<Quest> curAccumulatedQuestList = [];
+    List<DailyQuest> curAccumulatedQuestList = [];
 
     for (var accumulatedQuest in _accumulatedQuestList) {
-      if (_dailyRecord.accumulatedQuestList.contains(accumulatedQuest.quest) ==
-          false) {
-        curAccumulatedQuestList.add(accumulatedQuest.quest);
+      String questName = accumulatedQuest.quest.name;
+      if (!_dailyRecord.dailyQuestList_accumulated.map((dailyQuest) => dailyQuest.name).contains(questName)) {
+        curAccumulatedQuestList.add(DailyQuest(name: questName, isDone: false));
       }
     }
 
-    if (curAccumulatedQuestList.isEmpty) {
-      return;
-    }
+
 
     showModalBottomSheet(
       context: context,
       builder: (BuildContext context) {
+        if (curAccumulatedQuestList.isEmpty) {
+          return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[ Text("추가 가능한 누적 퀘스트가 없습니다.")]);
+        }
         return Column(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
@@ -231,8 +234,8 @@ class _SecondPageState extends State<SecondPage> {
                     title: Text(curAccumulatedQuestList[index].name),
                     onTap: () async {
                       setState(() {
-                        _dailyRecord.accumulatedQuestList.add(
-                          _accumulatedQuestList[index].quest,
+                        _dailyRecord.dailyQuestList_accumulated.add(
+                          curAccumulatedQuestList[index],
                         );
                       });
 
@@ -256,7 +259,7 @@ class _SecondPageState extends State<SecondPage> {
     final TextEditingController diaryController = TextEditingController();
 
     if (index != null) {
-      diaryController.text = _dailyRecord.normalQuestList[index].name;
+      diaryController.text = _dailyRecord.dailyQuestList_normal[index].name;
     }
 
     showDialog(
@@ -296,11 +299,11 @@ class _SecondPageState extends State<SecondPage> {
                         if (normalQuest.isNotEmpty) {
                           setState(() {
                             if (index == null) {
-                              _dailyRecord.normalQuestList.add(
-                                Quest(name: normalQuest, isDone: false),
+                              _dailyRecord.dailyQuestList_normal.add(
+                                DailyQuest(name: normalQuest, isDone: false),
                               );
                             } else {
-                              _dailyRecord.normalQuestList[index].name =
+                              _dailyRecord.dailyQuestList_normal[index].name =
                                   normalQuest;
                             }
                           });
@@ -458,7 +461,7 @@ class _SecondPageState extends State<SecondPage> {
                       child: Divider(
                           thickness: 0.5, color: AppColors.lightGreyColor),
                     ),
-                    _dailyRecord.accumulatedQuestList.isEmpty
+                    _dailyRecord.dailyQuestList_accumulated.isEmpty
                         ? Section(
                             title: '누적 퀘스트',
                             subtitle: '누적 퀘스트를 추가해보세요!',
@@ -466,7 +469,7 @@ class _SecondPageState extends State<SecondPage> {
                           )
                         : AccumulatedQuestSection(
                             accumulatedQuestList:
-                                _dailyRecord.accumulatedQuestList,
+                                _dailyRecord.dailyQuestList_accumulated,
                             updateAccumulatedQuest: _updateAccumulatedQuest,
                             deleteAccumulatedQuest: _deleteAccumulatedQuest,
                             showAccumulatedQuestModal:
@@ -477,14 +480,14 @@ class _SecondPageState extends State<SecondPage> {
                       child: Divider(
                           thickness: 0.5, color: AppColors.lightGreyColor),
                     ),
-                    _dailyRecord.normalQuestList.isEmpty
+                    _dailyRecord.dailyQuestList_normal.isEmpty
                         ? Section(
                             title: '일반 퀘스트',
                             subtitle: '일반 퀘스트를 추가해보세요!',
                             onPressed: _showNormalQuestModal,
                           )
                         : NormalQuestSection(
-                            normalQuestList: _dailyRecord.normalQuestList,
+                            normalQuestList: _dailyRecord.dailyQuestList_normal,
                             updateNormalQuest: _updateNormalQuest,
                             deleteNormalQuest: _deleteNormalQuest,
                             showNormalQuestModal: _showNormalQuestModal),

--- a/lib/second_page/widget.dart
+++ b/lib/second_page/widget.dart
@@ -156,7 +156,7 @@ class DiarySection extends StatelessWidget {
 }
 
 class AccumulatedQuestSection extends StatelessWidget {
-  final List<Quest> accumulatedQuestList;
+  final List<DailyQuest> accumulatedQuestList;
   final Future Function(int) updateAccumulatedQuest;
   final Future Function(int) deleteAccumulatedQuest;
   final void Function(BuildContext) showAccumulatedQuestModal;
@@ -291,7 +291,7 @@ class AccumulatedQuestSection extends StatelessWidget {
 }
 
 class NormalQuestSection extends StatelessWidget {
-  final List<Quest> normalQuestList;
+  final List<DailyQuest> normalQuestList;
   final Future Function(int) updateNormalQuest;
   final Future Function(int) deleteNormalQuest;
   final void Function(BuildContext, {int? index}) showNormalQuestModal;

--- a/lib/third_page/record_layout.dart
+++ b/lib/third_page/record_layout.dart
@@ -98,13 +98,13 @@ void _showRecordDetails(DailyRecord record) {
                     ),
                     const SizedBox(height: AppConstants.bigPadding),
                   ],
-                  if (record.accumulatedQuestList.any((quest) => quest.isDone)) ...[
+                  if (record.dailyQuestList_accumulated.any((quest) => quest.isDone)) ...[
                     Text(
                       '누적 퀘스트',
                       style: AppFonts.middleWhiteText(context),
                     ),
                     const SizedBox(height: AppConstants.smallPadding),
-                    ...record.accumulatedQuestList
+                    ...record.dailyQuestList_accumulated
                         .where((quest) => quest.isDone)
                         .map((quest) => _buildQuestItem(quest))
                         .toList(),
@@ -115,13 +115,13 @@ void _showRecordDetails(DailyRecord record) {
                     ),
                     const SizedBox(height: AppConstants.bigPadding),
                   ],
-                  if (record.normalQuestList.any((quest) => quest.isDone)) ...[
+                  if (record.dailyQuestList_normal.any((quest) => quest.isDone)) ...[
                     Text(
                       '일반 퀘스트',
                       style: AppFonts.middleWhiteText(context),
                     ),
                     const SizedBox(height: AppConstants.smallPadding),
-                    ...record.normalQuestList
+                    ...record.dailyQuestList_normal
                         .where((quest) => quest.isDone)
                         .map((quest) => _buildQuestItem(quest))
                         .toList(),
@@ -162,7 +162,7 @@ void _showRecordDetails(DailyRecord record) {
 
 
 
-  Widget _buildQuestItem(Quest quest) {
+  Widget _buildQuestItem(DailyQuest quest) {
     return Container(
       padding: const EdgeInsets.all(AppConstants.smallPadding),
       margin: const EdgeInsets.only(bottom: AppConstants.smallPadding),

--- a/lib/types/accumulated_quest.dart
+++ b/lib/types/accumulated_quest.dart
@@ -8,7 +8,7 @@ part 'accumulated_quest.g.dart';
 @HiveType(typeId: 2)
 class AccumulatedQuest extends HiveObject {
   @HiveField(0)
-  Quest quest = Quest(name: '', isDone: false);
+  DailyQuest quest = DailyQuest(name: '', isDone: false);
 
   @HiveField(1)
   List<DateTime> dates = [];

--- a/lib/types/accumulated_quest.g.dart
+++ b/lib/types/accumulated_quest.g.dart
@@ -17,7 +17,7 @@ class AccumulatedQuestAdapter extends TypeAdapter<AccumulatedQuest> {
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return AccumulatedQuest(
-      quest: fields[0] as Quest,
+      quest: fields[0] as DailyQuest,
     )
       ..dates = (fields[1] as List).cast<DateTime>()
       ..tier = fields[2] as int

--- a/lib/types/daily_record.dart
+++ b/lib/types/daily_record.dart
@@ -13,10 +13,10 @@ class DailyRecord extends HiveObject {
   String diary = '';
 
   @HiveField(2)
-  List<Quest> accumulatedQuestList = [];
+  List<DailyQuest> dailyQuestList_accumulated = [];
 
   @HiveField(3)
-  List<Quest> normalQuestList = [];
+  List<DailyQuest> dailyQuestList_normal = [];
 
   @HiveField(4)
   int facialExpressionIndex = -1;
@@ -27,8 +27,8 @@ class DailyRecord extends HiveObject {
   DailyRecord({
     required this.date,
     required this.diary,
-    required this.accumulatedQuestList,
-    required this.normalQuestList,
+    required this.dailyQuestList_accumulated,
+    required this.dailyQuestList_normal,
     required this.facialExpressionIndex,
     required this.isSaved,
   });

--- a/lib/types/daily_record.g.dart
+++ b/lib/types/daily_record.g.dart
@@ -19,8 +19,8 @@ class DailyRecordAdapter extends TypeAdapter<DailyRecord> {
     return DailyRecord(
       date: fields[0] as DateTime,
       diary: fields[1] as String,
-      accumulatedQuestList: (fields[2] as List).cast<Quest>(),
-      normalQuestList: (fields[3] as List).cast<Quest>(),
+      dailyQuestList_accumulated: (fields[2] as List).cast<DailyQuest>(),
+      dailyQuestList_normal: (fields[3] as List).cast<DailyQuest>(),
       facialExpressionIndex: fields[4] as int,
       isSaved: fields[5] as bool,
     );
@@ -35,9 +35,9 @@ class DailyRecordAdapter extends TypeAdapter<DailyRecord> {
       ..writeByte(1)
       ..write(obj.diary)
       ..writeByte(2)
-      ..write(obj.accumulatedQuestList)
+      ..write(obj.dailyQuestList_accumulated)
       ..writeByte(3)
-      ..write(obj.normalQuestList)
+      ..write(obj.dailyQuestList_normal)
       ..writeByte(4)
       ..write(obj.facialExpressionIndex)
       ..writeByte(5)

--- a/lib/types/quest.dart
+++ b/lib/types/quest.dart
@@ -3,14 +3,14 @@ import 'package:hive/hive.dart';
 part 'quest.g.dart';
 
 @HiveType(typeId: 0)
-class Quest extends HiveObject {
+class DailyQuest extends HiveObject {
   @HiveField(0)
   String name = '';
 
   @HiveField(1)
   bool isDone = false;
 
-  Quest({
+  DailyQuest({
     required this.name,
     required this.isDone,
   });

--- a/lib/types/quest.g.dart
+++ b/lib/types/quest.g.dart
@@ -6,24 +6,24 @@ part of 'quest.dart';
 // TypeAdapterGenerator
 // **************************************************************************
 
-class QuestAdapter extends TypeAdapter<Quest> {
+class QuestAdapter extends TypeAdapter<DailyQuest> {
   @override
   final int typeId = 0;
 
   @override
-  Quest read(BinaryReader reader) {
+  DailyQuest read(BinaryReader reader) {
     final numOfFields = reader.readByte();
     final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
-    return Quest(
+    return DailyQuest(
       name: fields[0] as String,
       isDone: fields[1] as bool,
     );
   }
 
   @override
-  void write(BinaryWriter writer, Quest obj) {
+  void write(BinaryWriter writer, DailyQuest obj) {
     writer
       ..writeByte(2)
       ..writeByte(0)


### PR DESCRIPTION
## Issue
누적 퀘스트 추가 시 선택한 누적퀘스트가 추가되지 않음.

## Description
- issue를 해결하기 전, DailyRecord의 accumulatedQuestList가 AccumulatedQuest의 Box에서 데이터들을 불러올 때 이용하는 acumulatedQuestList와 명칭이 중복되어 변수명들을 바꾸었다.
     - Quest -> DailyQuest
     - DailyRecord.accumulatedQuestList -> DailyRecord.dailyQuestList_accumulated
     - DailyRecord.normalQuestList -> DailyRecord.dailyQuestList_normal
    
- issue/#32 fix
    - ListTile 을 탭했을 때 curAccumulatedQuestList[index]를 추가해야 함.

- UI 개선
    - 더 이상 추가가능한 누적퀘스트가 없을 때 없다고 하단에 메시지를 띄운다.

## Check List

- [x] PR의 제목을 규칙에 맞게 작성
- [x] 코드 리뷰어 지정
- [x] PR과 이슈 연결 완료
- [x] 적절한 담당자 및 라벨 설정
- [x] 변경 사항을 스크린샷으로 첨부할 수 있는 경우 첨부
- [x] main 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot
